### PR TITLE
fix sieving in ExNihiloSequentia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `IngredientUtils` is essentially defunct
 - Fluid textures are no longer set in `FluidDefinition`
 
+### Fixed
+
+- fixed function `novamachina.novacore.util.IngredientUtils.isIngredientIn` to not always return `false`
+
 ## [3.0.0](https://github.com/NovaMachina-Mods/NovaCore/compare/v2.0.0...v3.0.0) - 2024-07-09
 
 ### Added

--- a/src/main/java/novamachina/novacore/util/IngredientUtils.java
+++ b/src/main/java/novamachina/novacore/util/IngredientUtils.java
@@ -17,11 +17,6 @@ public class IngredientUtils {
    * @return true if test is a subset of source, false otherwise
    */
   public static boolean isIngredientIn(Ingredient test, Ingredient source) {
-    //    for (Holder<Item> stack : test.items()) {
-    //      if (source.test(new ItemStack(stack))) {
-    //        return true;
-    //      }
-    //    }
-    return false;
+    return test.items().anyMatch(stack -> source.acceptsItem(stack));
   }
 }


### PR DESCRIPTION
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you updated the changelog as appropriate (1.20.4+ only)?
* [x] Do all dependencies point to non-LOCAL variants?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


This PR introduces a Bugfix for function `novamachina.novacore.util.IngredientUtils.isIngredientIn`. It previously returned `false` on every call. I used the commented-out code and modified it to work as intended.

This fixes the issue https://github.com/NovaMachina-Mods/ExNihiloSequentia/issues/476 in ExNihiloSequentia (sieves did not sift). Thanks to @LiuJiewenTT for pointing out why!